### PR TITLE
Add initial automated release notes config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+# Copyright 2024 Adam Chalkley
+#
+# https://github.com/atc0005/cert-payload
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking
+    - title: New Features or Enhancements 🎉
+      labels:
+        - new
+        - enhancement
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+    - title: Dependency Updates
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
This is one of the pieces to automate release builds for this project.

See also:

- refs atc0005/todo#65
- fixes GH-6