### PR TITLE
Drop copyloopvar linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,6 @@ issues:
 
 linters:
   enable:
-    - copyloopvar
     - dogsled
     - dupl
     - goconst


### PR DESCRIPTION
This linter requires Go 1.22 or greater and this project still uses Go 1.19 as the baseline.