### PR TITLE
Update `ValidityPeriod*` constants

### DIFF
--- a/payload.go
+++ b/payload.go
@@ -23,10 +23,28 @@ const (
 )
 
 // Validity period keywords intended as human readable output.
+//
+// Common historical certificate lifetimes:
+//
+// - 5 year (1825 days, 60 months)
+// - 3 year (1185 days, 39 months)
+// - 2 year (825 days, 27 months)
+// - 1 year (398 days, 13 months)
+//
+// See also:
+//
+// - https://www.sectigo.com/knowledge-base/detail/TLS-SSL-Certificate-Lifespan-History-2-3-and-5-year-validity/kA01N000000zFKp
+// - https://support.sectigo.com/Com_KnowledgeDetailPage?Id=kA03l000000o6cv
+// - https://www.digicert.com/faq/public-trust-and-certificates/how-long-are-tls-ssl-certificate-validity-periods
+// - https://docs.digicert.com/en/whats-new/change-log/older-changes/change-log--2023.html#certcentral--changes-to-multi-year-plan-coverage
+// - https://knowledge.digicert.com/quovadis/ssl-certificates/ssl-general-topics/maximum-validity-changes-for-tls-ssl-to-drop-to-825-days-in-q1-2018
+// - https://chromium.googlesource.com/chromium/src/+/666712ff6c7ba7aa5da380bc0a617b637c9232b3/net/docs/certificate_lifetimes.md
+// - https://www.entrust.com/blog/2017/03/maximum-certificate-lifetime-drops-to-825-days-in-2018
 const (
-	ValidityPeriod1Year string = "1 year"
-	ValidityPeriod90Day string = "90 day"
-	ValidityPeriod45Day string = "45 day"
+	ValidityPeriod1Year   string = "1 year"
+	ValidityPeriod90Days  string = "90 days"
+	ValidityPeriod45Days  string = "45 days"
+	ValidityPeriodUNKNOWN string = "UNKNOWN"
 )
 
 var (


### PR DESCRIPTION
- add new `ValidityPeriodUNKNOWN` value
- change from singular "day" to "days"
- add doc comments listing common historical cert lifetimes along with references where most of the info was sourced