### PR TITLE
Add Certificates collection type & initial methods

### DIFF
--- a/format/v0/certificates.go
+++ b/format/v0/certificates.go
@@ -1,0 +1,317 @@
+// Copyright 2024 Adam Chalkley
+//
+// https://github.com/atc0005/cert-payload
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package format0
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/atc0005/cert-payload/internal/certs"
+)
+
+// Certificate evaluation status values.
+const (
+	// CertNotPresent indicates that a certificate chain was successfully
+	// retrieved, but a specific certificate was not present in the chain.
+	CertNotPresentInChain string = "not present"
+
+	// CertChainNotFound indicates that a certificate chain was not
+	// successfully retrieved, so we can not make a determination whether a
+	// specific certificate is present in the chain.
+	CertChainNotFound string = "cert chain not found"
+)
+
+// LowestCertLifetimeValue returns the lowest remaining lifetime between
+// certificates in the certificate chain.
+func (cs Certificates) LowestCertLifetimeValue() float64 {
+	var lowest float64
+
+	// Seed starting value
+	if len(cs) > 0 {
+		lowest = cs[0].DaysRemaining
+	}
+
+	for _, cert := range cs {
+		if cert.DaysRemaining < lowest {
+			lowest = cert.DaysRemaining
+		}
+	}
+
+	return lowest
+}
+
+// HighestCertLifetimeValue returns the highest remaining lifetime between
+// certificates in the certificate chain.
+func (cs Certificates) HighestCertLifetimeValue() float64 {
+	var highest float64
+
+	for _, cert := range cs {
+		if cert.DaysRemaining > highest {
+			highest = cert.DaysRemaining
+		}
+	}
+
+	return highest
+}
+
+// LowestLeafCertLifetimeValue returns the lowest remaining lifetime between
+// leaf certificates in the certificate chain.
+func (cs Certificates) LowestLeafCertLifetimeValue() float64 {
+	var lowest float64
+
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionLeaf {
+			if lowest == 0 {
+				lowest = cert.DaysRemaining
+			}
+
+			if cert.DaysRemaining < lowest {
+				lowest = cert.DaysRemaining
+			}
+		}
+	}
+
+	return lowest
+}
+
+// HighestLeafCertLifetimeValue returns the highest remaining lifetime between
+// leaf certificates in the certificate chain.
+func (cs Certificates) HighestLeafCertLifetimeValue() float64 {
+	var highest float64
+
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionLeaf {
+			if cert.DaysRemaining > highest {
+				highest = cert.DaysRemaining
+			}
+		}
+	}
+
+	return highest
+}
+
+// HasExpiringLeafs indicates that there is an expiring intermediate
+// certificate in the certificate chain.
+func (cs Certificates) HasExpiringLeafs() bool {
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionLeaf {
+			if cert.Status.Expiring {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// HasExpiredLeafs indicates that there is an expired leaf certificate
+// in the certificate chain.
+func (cs Certificates) HasExpiredLeafs() bool {
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionLeaf {
+			if cert.Status.Expired {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// LowestIntermediateCertLifetimeValue returns the lowest remaining lifetime
+// between intermediate certificates in the certificate chain.
+func (cs Certificates) LowestIntermediateCertLifetimeValue() float64 {
+	var lowest float64
+
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionIntermediate {
+			if lowest == 0 {
+				lowest = cert.DaysRemaining
+			}
+
+			if cert.DaysRemaining < lowest {
+				lowest = cert.DaysRemaining
+			}
+		}
+	}
+
+	return lowest
+}
+
+// HighestIntermediateCertLifetimeValue returns the highest remaining lifetime
+// between intermediate certificates in the certificate chain.
+func (cs Certificates) HighestIntermediateCertLifetimeValue() float64 {
+	var highest float64
+
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionIntermediate {
+			if cert.DaysRemaining > highest {
+				highest = cert.DaysRemaining
+			}
+		}
+	}
+
+	return highest
+}
+
+// HasExpiringIntermediates indicates that there is an expiring intermediate
+// certificate in the certificate chain.
+func (cs Certificates) HasExpiringIntermediates() bool {
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionIntermediate {
+			if cert.Status.Expiring {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// HasExpiredIntermediates indicates that there is an expired intermediate
+// certificate in the certificate chain.
+func (cs Certificates) HasExpiredIntermediates() bool {
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionIntermediate {
+			if cert.Status.Expired {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// IntermediateExpiringFirst returns the intermediate certificate expiring
+// first in the certificate chain or a zero value Certificate if there isn't
+// one.
+func (cs Certificates) IntermediateExpiringFirst() Certificate {
+	var lowestIntermediate Certificate
+
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionIntermediate {
+			if lowestIntermediate.IssuedOn.IsZero() {
+				lowestIntermediate = cert
+			}
+
+			if cert.DaysRemaining < lowestIntermediate.DaysRemaining {
+				lowestIntermediate = cert
+			}
+		}
+	}
+
+	return lowestIntermediate
+}
+
+// FirstLeaf returns the first leaf certificate in the certificate chain or a
+// zero value Certificate if there isn't one (e.g., a manually constructed
+// chain).
+func (cs Certificates) FirstLeaf() Certificate {
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionLeaf {
+			return cert
+		}
+	}
+
+	return Certificate{}
+}
+
+// LeafExpirationDescription returns a human readable version of the
+// expiration details for the first leaf certificate in the certificate chain.
+func (cs Certificates) LeafExpirationDescription() string {
+	var firstLeaf Certificate
+
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionLeaf {
+			firstLeaf = cert
+		}
+	}
+
+	switch {
+	case firstLeaf.IssuedOn.IsZero():
+		// We couldn't find a leaf cert, which means we effectively don't have
+		// a certificate chain as a leaf certificate is required to establish
+		// a TLS connection.
+		return CertChainNotFound
+
+	default:
+		return fmt.Sprintf(
+			"%s (%s)",
+			FormattedExpiration(firstLeaf, "", ""),
+			FormattedLifetime(firstLeaf),
+		)
+	}
+}
+
+// IntermediateExpirationDescription returns a human readable version of the
+// expiration details for the intermediate certificate expiring first in the
+// certificate chain.
+func (cs Certificates) IntermediateExpirationDescription() string {
+	oldestIntermediate := cs.IntermediateExpiringFirst()
+
+	switch {
+	case oldestIntermediate.IssuedOn.IsZero():
+		return CertNotPresentInChain
+
+	default:
+		return fmt.Sprintf(
+			"%s (%s)",
+			FormattedExpiration(oldestIntermediate, "", ""),
+			FormattedLifetime(oldestIntermediate),
+		)
+	}
+}
+
+// FormattedExpiration formats the expiration date for the given certificate
+// using an optional custom unit of measurement and an optional precision
+// format string.
+func FormattedExpiration(cert Certificate, uom string, precisionFmtString string) string {
+	var leadInText string
+
+	defaultUOM := "d" // days
+	if uom == "" {
+		uom = defaultUOM
+	}
+
+	daysRemaining := cert.DaysRemaining
+
+	if daysRemaining < 0 {
+		// If negative value, flip to positive.
+		daysRemaining = float64(math.Abs(daysRemaining))
+
+		// Since we're tracking time (using 'd' as default uom for days),
+		// we'll use "ago" to communicate that the event has already occurred.
+		uom += " ago"
+
+		leadInText = "expired "
+	}
+
+	// Opt for one decimal place over two by default to reduce visual "noise".
+	defaultPrecisionFmtString := "%.1f"
+
+	if precisionFmtString == "" {
+		precisionFmtString = defaultPrecisionFmtString
+	}
+
+	fmtString := "%s" + precisionFmtString + "%s"
+
+	return fmt.Sprintf(fmtString, leadInText, daysRemaining, uom)
+}
+
+// FormattedLifetime formats the remaining (positive) lifetime for a given
+// certificate.
+func FormattedLifetime(cert Certificate) string {
+	uom := "%"
+	lifetime := cert.LifetimePercent
+
+	if lifetime < 0 {
+		lifetime = 0
+	}
+
+	return fmt.Sprintf("%d%s left", lifetime, uom)
+}

--- a/format/v0/types.go
+++ b/format/v0/types.go
@@ -140,6 +140,10 @@ type Certificate struct {
 	Type string `json:"type"`
 }
 
+// Certificates is a collection of Certificate values from a single
+// certificate chain.
+type Certificates []Certificate
+
 // CertificateChainIssues is an aggregated collection of problems detected for
 // the certificate chain.
 type CertificateChainIssues struct {

--- a/format/v1/certificates.go
+++ b/format/v1/certificates.go
@@ -1,0 +1,317 @@
+// Copyright 2024 Adam Chalkley
+//
+// https://github.com/atc0005/cert-payload
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package format1
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/atc0005/cert-payload/internal/certs"
+)
+
+// Certificate evaluation status values.
+const (
+	// CertNotPresent indicates that a certificate chain was successfully
+	// retrieved, but a specific certificate was not present in the chain.
+	CertNotPresentInChain string = "not present"
+
+	// CertChainNotFound indicates that a certificate chain was not
+	// successfully retrieved, so we can not make a determination whether a
+	// specific certificate is present in the chain.
+	CertChainNotFound string = "cert chain not found"
+)
+
+// LowestCertLifetimeValue returns the lowest remaining lifetime between
+// certificates in the certificate chain.
+func (cs Certificates) LowestCertLifetimeValue() float64 {
+	var lowest float64
+
+	// Seed starting value
+	if len(cs) > 0 {
+		lowest = cs[0].DaysRemaining
+	}
+
+	for _, cert := range cs {
+		if cert.DaysRemaining < lowest {
+			lowest = cert.DaysRemaining
+		}
+	}
+
+	return lowest
+}
+
+// HighestCertLifetimeValue returns the highest remaining lifetime between
+// certificates in the certificate chain.
+func (cs Certificates) HighestCertLifetimeValue() float64 {
+	var highest float64
+
+	for _, cert := range cs {
+		if cert.DaysRemaining > highest {
+			highest = cert.DaysRemaining
+		}
+	}
+
+	return highest
+}
+
+// LowestLeafCertLifetimeValue returns the lowest remaining lifetime between
+// leaf certificates in the certificate chain.
+func (cs Certificates) LowestLeafCertLifetimeValue() float64 {
+	var lowest float64
+
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionLeaf {
+			if lowest == 0 {
+				lowest = cert.DaysRemaining
+			}
+
+			if cert.DaysRemaining < lowest {
+				lowest = cert.DaysRemaining
+			}
+		}
+	}
+
+	return lowest
+}
+
+// HighestLeafCertLifetimeValue returns the highest remaining lifetime between
+// leaf certificates in the certificate chain.
+func (cs Certificates) HighestLeafCertLifetimeValue() float64 {
+	var highest float64
+
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionLeaf {
+			if cert.DaysRemaining > highest {
+				highest = cert.DaysRemaining
+			}
+		}
+	}
+
+	return highest
+}
+
+// HasExpiringLeafs indicates that there is an expiring intermediate
+// certificate in the certificate chain.
+func (cs Certificates) HasExpiringLeafs() bool {
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionLeaf {
+			if cert.Status.Expiring {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// HasExpiredLeafs indicates that there is an expired leaf certificate
+// in the certificate chain.
+func (cs Certificates) HasExpiredLeafs() bool {
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionLeaf {
+			if cert.Status.Expired {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// LowestIntermediateCertLifetimeValue returns the lowest remaining lifetime
+// between intermediate certificates in the certificate chain.
+func (cs Certificates) LowestIntermediateCertLifetimeValue() float64 {
+	var lowest float64
+
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionIntermediate {
+			if lowest == 0 {
+				lowest = cert.DaysRemaining
+			}
+
+			if cert.DaysRemaining < lowest {
+				lowest = cert.DaysRemaining
+			}
+		}
+	}
+
+	return lowest
+}
+
+// HighestIntermediateCertLifetimeValue returns the highest remaining lifetime
+// between intermediate certificates in the certificate chain.
+func (cs Certificates) HighestIntermediateCertLifetimeValue() float64 {
+	var highest float64
+
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionIntermediate {
+			if cert.DaysRemaining > highest {
+				highest = cert.DaysRemaining
+			}
+		}
+	}
+
+	return highest
+}
+
+// HasExpiringIntermediates indicates that there is an expiring intermediate
+// certificate in the certificate chain.
+func (cs Certificates) HasExpiringIntermediates() bool {
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionIntermediate {
+			if cert.Status.Expiring {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// HasExpiredIntermediates indicates that there is an expired intermediate
+// certificate in the certificate chain.
+func (cs Certificates) HasExpiredIntermediates() bool {
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionIntermediate {
+			if cert.Status.Expired {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// IntermediateExpiringFirst returns the intermediate certificate expiring
+// first in the certificate chain or a zero value Certificate if there isn't
+// one.
+func (cs Certificates) IntermediateExpiringFirst() Certificate {
+	var lowestIntermediate Certificate
+
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionIntermediate {
+			if lowestIntermediate.IssuedOn.IsZero() {
+				lowestIntermediate = cert
+			}
+
+			if cert.DaysRemaining < lowestIntermediate.DaysRemaining {
+				lowestIntermediate = cert
+			}
+		}
+	}
+
+	return lowestIntermediate
+}
+
+// FirstLeaf returns the first leaf certificate in the certificate chain or a
+// zero value Certificate if there isn't one (e.g., a manually constructed
+// chain).
+func (cs Certificates) FirstLeaf() Certificate {
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionLeaf {
+			return cert
+		}
+	}
+
+	return Certificate{}
+}
+
+// LeafExpirationDescription returns a human readable version of the
+// expiration details for the first leaf certificate in the certificate chain.
+func (cs Certificates) LeafExpirationDescription() string {
+	var firstLeaf Certificate
+
+	for _, cert := range cs {
+		if cert.Type == certs.CertChainPositionLeaf {
+			firstLeaf = cert
+		}
+	}
+
+	switch {
+	case firstLeaf.IssuedOn.IsZero():
+		// We couldn't find a leaf cert, which means we effectively don't have
+		// a certificate chain as a leaf certificate is required to establish
+		// a TLS connection.
+		return CertChainNotFound
+
+	default:
+		return fmt.Sprintf(
+			"%s (%s)",
+			FormattedExpiration(firstLeaf, "", ""),
+			FormattedLifetime(firstLeaf),
+		)
+	}
+}
+
+// IntermediateExpirationDescription returns a human readable version of the
+// expiration details for the intermediate certificate expiring first in the
+// certificate chain.
+func (cs Certificates) IntermediateExpirationDescription() string {
+	oldestIntermediate := cs.IntermediateExpiringFirst()
+
+	switch {
+	case oldestIntermediate.IssuedOn.IsZero():
+		return CertNotPresentInChain
+
+	default:
+		return fmt.Sprintf(
+			"%s (%s)",
+			FormattedExpiration(oldestIntermediate, "", ""),
+			FormattedLifetime(oldestIntermediate),
+		)
+	}
+}
+
+// FormattedExpiration formats the expiration date for the given certificate
+// using an optional custom unit of measurement and an optional precision
+// format string.
+func FormattedExpiration(cert Certificate, uom string, precisionFmtString string) string {
+	var leadInText string
+
+	defaultUOM := "d" // days
+	if uom == "" {
+		uom = defaultUOM
+	}
+
+	daysRemaining := cert.DaysRemaining
+
+	if daysRemaining < 0 {
+		// If negative value, flip to positive.
+		daysRemaining = float64(math.Abs(daysRemaining))
+
+		// Since we're tracking time (using 'd' as default uom for days),
+		// we'll use "ago" to communicate that the event has already occurred.
+		uom += " ago"
+
+		leadInText = "expired "
+	}
+
+	// Opt for one decimal place over two by default to reduce visual "noise".
+	defaultPrecisionFmtString := "%.1f"
+
+	if precisionFmtString == "" {
+		precisionFmtString = defaultPrecisionFmtString
+	}
+
+	fmtString := "%s" + precisionFmtString + "%s"
+
+	return fmt.Sprintf(fmtString, leadInText, daysRemaining, uom)
+}
+
+// FormattedLifetime formats the remaining (positive) lifetime for a given
+// certificate.
+func FormattedLifetime(cert Certificate) string {
+	uom := "%"
+	lifetime := cert.LifetimePercent
+
+	if lifetime < 0 {
+		lifetime = 0
+	}
+
+	return fmt.Sprintf("%d%s left", lifetime, uom)
+}

--- a/format/v1/types.go
+++ b/format/v1/types.go
@@ -135,6 +135,10 @@ type Certificate struct {
 	Type string `json:"type"`
 }
 
+// Certificates is a collection of Certificate values from a single
+// certificate chain.
+type Certificates []Certificate
+
 // CertificateChainIssues is an aggregated collection of problems detected for
 // the certificate chain.
 type CertificateChainIssues struct {

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -27,12 +27,13 @@ var (
 	ErrMissingValue = errors.New("missing expected value")
 )
 
+// Certificate type values for display and comparison purposes.
 const (
-	certChainPositionLeaf           string = "leaf"
-	certChainPositionLeafSelfSigned string = "leaf; self-signed"
-	certChainPositionIntermediate   string = "intermediate"
-	certChainPositionRoot           string = "root"
-	certChainPositionUnknown        string = "UNKNOWN cert chain position; please submit a bug report"
+	CertChainPositionLeaf           string = "leaf"
+	CertChainPositionLeafSelfSigned string = "leaf; self-signed"
+	CertChainPositionIntermediate   string = "intermediate"
+	CertChainPositionRoot           string = "root"
+	CertChainPositionUnknown        string = "UNKNOWN cert chain position; please submit a bug report"
 )
 
 // Nagios plugin/service check state "labels". These values are used (where
@@ -132,7 +133,7 @@ func ChainPosition(cert *x509.Certificate, certChain []*x509.Certificate) string
 
 	// We require a valid certificate chain. Fail if not provided.
 	if certChain == nil {
-		return certChainPositionUnknown
+		return CertChainPositionUnknown
 	}
 
 	switch cert.Version {
@@ -146,17 +147,17 @@ func ChainPosition(cert *x509.Certificate, certChain []*x509.Certificate) string
 		switch {
 		case isSelfSigned(cert):
 			if cert == certChain[0] {
-				return certChainPositionLeafSelfSigned
+				return CertChainPositionLeafSelfSigned
 			}
 
-			return certChainPositionRoot
+			return CertChainPositionRoot
 
 		default:
 			if cert == certChain[0] {
-				return certChainPositionLeaf
+				return CertChainPositionLeaf
 			}
 
-			return certChainPositionIntermediate
+			return CertChainPositionIntermediate
 		}
 
 	case 3:
@@ -169,7 +170,7 @@ func ChainPosition(cert *x509.Certificate, certChain []*x509.Certificate) string
 			// The cA boolean indicates whether the certified public key may be
 			// used to verify certificate signatures.
 			if cert.IsCA {
-				return certChainPositionRoot
+				return CertChainPositionRoot
 			}
 
 			// The Extended key usage extension indicates one or more purposes
@@ -178,7 +179,7 @@ func ChainPosition(cert *x509.Certificate, certChain []*x509.Certificate) string
 			// extension. In general, this extension will appear only in end
 			// entity certificates.
 			if cert.ExtKeyUsage != nil {
-				return certChainPositionLeafSelfSigned
+				return CertChainPositionLeafSelfSigned
 			}
 
 			// CA certs are intended for cert and CRL signing.
@@ -188,11 +189,11 @@ func ChainPosition(cert *x509.Certificate, certChain []*x509.Certificate) string
 			// Constraints` are specified.
 			switch cert.KeyUsage {
 			case cert.KeyUsage | x509.KeyUsageCertSign | x509.KeyUsageCRLSign:
-				return certChainPositionRoot
+				return CertChainPositionRoot
 			case cert.KeyUsage | x509.KeyUsageCertSign:
-				return certChainPositionRoot
+				return CertChainPositionRoot
 			default:
-				return certChainPositionLeafSelfSigned
+				return CertChainPositionLeafSelfSigned
 			}
 
 		default:
@@ -200,7 +201,7 @@ func ChainPosition(cert *x509.Certificate, certChain []*x509.Certificate) string
 			// The cA boolean indicates whether the certified public key may be
 			// used to verify certificate signatures.
 			if cert.IsCA {
-				return certChainPositionIntermediate
+				return CertChainPositionIntermediate
 			}
 
 			// The Extended key usage extension indicates one or more purposes
@@ -209,7 +210,7 @@ func ChainPosition(cert *x509.Certificate, certChain []*x509.Certificate) string
 			// extension. In general, this extension will appear only in end
 			// entity certificates.
 			if cert.ExtKeyUsage != nil {
-				return certChainPositionLeaf
+				return CertChainPositionLeaf
 			}
 
 			// CA certs are intended for cert and CRL signing.
@@ -219,18 +220,18 @@ func ChainPosition(cert *x509.Certificate, certChain []*x509.Certificate) string
 			// Constraints` are specified.
 			switch cert.KeyUsage {
 			case cert.KeyUsage | x509.KeyUsageCertSign | x509.KeyUsageCRLSign:
-				return certChainPositionIntermediate
+				return CertChainPositionIntermediate
 			case cert.KeyUsage | x509.KeyUsageCertSign:
-				return certChainPositionIntermediate
+				return CertChainPositionIntermediate
 			default:
-				return certChainPositionLeaf
+				return CertChainPositionLeaf
 			}
 
 		}
 	}
 
 	// no known match, so position unknown
-	return certChainPositionUnknown
+	return CertChainPositionUnknown
 
 }
 
@@ -258,9 +259,9 @@ func NumLeafCerts(certChain []*x509.Certificate) int {
 	for _, cert := range certChain {
 		chainPos := ChainPosition(cert, certChain)
 		switch chainPos {
-		case certChainPositionLeaf:
+		case CertChainPositionLeaf:
 			num++
-		case certChainPositionLeafSelfSigned:
+		case CertChainPositionLeafSelfSigned:
 			num++
 		}
 	}
@@ -274,7 +275,7 @@ func NumIntermediateCerts(certChain []*x509.Certificate) int {
 	var num int
 	for _, cert := range certChain {
 		chainPos := ChainPosition(cert, certChain)
-		if chainPos == certChainPositionIntermediate {
+		if chainPos == CertChainPositionIntermediate {
 			num++
 		}
 	}
@@ -290,7 +291,7 @@ func NonRootCerts(certChain []*x509.Certificate) []*x509.Certificate {
 
 	for _, cert := range certChain {
 		chainPos := ChainPosition(cert, certChain)
-		if chainPos != certChainPositionRoot {
+		if chainPos != CertChainPositionRoot {
 			nonRootCerts = append(nonRootCerts, cert)
 		}
 	}
@@ -307,9 +308,9 @@ func LeafCerts(certChain []*x509.Certificate) []*x509.Certificate {
 	for _, cert := range certChain {
 		chainPos := ChainPosition(cert, certChain)
 		switch chainPos {
-		case certChainPositionLeaf:
+		case CertChainPositionLeaf:
 			leafCerts = append(leafCerts, cert)
-		case certChainPositionLeafSelfSigned:
+		case CertChainPositionLeafSelfSigned:
 			leafCerts = append(leafCerts, cert)
 		}
 
@@ -494,7 +495,7 @@ func ExpirationStatus(cert *x509.Certificate, ageCritical time.Time, ageWarning 
 func HasWeakSignatureAlgorithm(cert *x509.Certificate, certChain []*x509.Certificate, evalRoot bool) bool {
 	chainPos := ChainPosition(cert, certChain)
 
-	if chainPos == certChainPositionRoot && !evalRoot {
+	if chainPos == CertChainPositionRoot && !evalRoot {
 		return false
 	}
 


### PR DESCRIPTION
Add helper methods/functions for comparing and displaying `Certificate` values from a `Certificates` collection.

As part of this, the certificate type constants within the internal/certs package have been exported for wider use within this library (not externally).

This new `Certificates` collection and behavior can be used when generating reports.

NOTE: I'm on the fence whether providing this support fits within the scope of this project. The intent is to generate and deconstruct certificate metadata payloads and let consumers of that metadata handle grouping, evaluating and displaying the data in formats of their choosing.

By providing even a little support to analyze and display the data this library takes on a role it was not *exactly* intended to handle.

In short, this support may be pulled later.