### PR TITLE
Refactor logic to resolve linting errors

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -5,6 +5,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root for
 // full license information.
 
+//nolint:gocognit // ignore function complexity
 package payload_test
 
 import (
@@ -28,6 +29,8 @@ import (
 // version (in this case format 0).
 //
 // TODO: Update this example once format version 1 is released.
+//
+//gocognit:ignore
 func Example_extractandDecodePayloadsFromNagiosXIAPI() {
 	if len(os.Args) < 2 {
 		fmt.Println("Missing input file")

--- a/format/v0/decode.go
+++ b/format/v0/decode.go
@@ -9,7 +9,6 @@ package format0
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 )
@@ -34,8 +33,10 @@ func Decode(dest *CertChainPayload, input io.Reader, allowUnknownFields bool) er
 
 	// If there is more than one object, something is off.
 	if dec.More() {
-		return errors.New(
-			"input contains multiple JSON objects; only one JSON object is supported",
+		return fmt.Errorf(
+			"input contains multiple JSON objects;"+
+				" only one JSON object is supported: %w",
+			ErrInvalidPayloadFormat,
 		)
 	}
 

--- a/format/v0/errors.go
+++ b/format/v0/errors.go
@@ -5,4 +5,8 @@ import "errors"
 var (
 	// ErrMissingValue indicates that an expected value was missing.
 	ErrMissingValue = errors.New("missing expected value")
+
+	// ErrInvalidPayloadFormat indicates that a given payload is in an
+	// unexpected format.
+	ErrInvalidPayloadFormat = errors.New("given payload format is invalid")
 )

--- a/format/v1/decode.go
+++ b/format/v1/decode.go
@@ -9,7 +9,6 @@ package format1
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 )
@@ -34,8 +33,10 @@ func Decode(dest *CertChainPayload, input io.Reader, allowUnknownFields bool) er
 
 	// If there is more than one object, something is off.
 	if dec.More() {
-		return errors.New(
-			"input contains multiple JSON objects; only one JSON object is supported",
+		return fmt.Errorf(
+			"input contains multiple JSON objects;"+
+				" only one JSON object is supported: %w",
+			ErrInvalidPayloadFormat,
 		)
 	}
 

--- a/format/v1/encode.go
+++ b/format/v1/encode.go
@@ -8,6 +8,7 @@
 package format1
 
 import (
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -61,19 +62,12 @@ func Encode(inputData input.Values) ([]byte, error) {
 			return nil, lookupErr
 		}
 
-		var SANsEntries []string
-		if inputData.OmitSANsEntries {
-			SANsEntries = nil
-		} else {
-			SANsEntries = origCert.DNSNames
-		}
-
 		validityPeriodDescription := shared.LookupValidityPeriodDescription(origCert)
 
 		certSubset := Certificate{
 			Subject:                   origCert.Subject.String(),
 			CommonName:                origCert.Subject.CommonName,
-			SANsEntries:               SANsEntries,
+			SANsEntries:               sansEntries(origCert, inputData),
 			SANsEntriesCount:          len(origCert.DNSNames),
 			Issuer:                    origCert.Issuer.String(),
 			IssuerShort:               origCert.Issuer.CommonName,
@@ -94,17 +88,7 @@ func Encode(inputData input.Values) ([]byte, error) {
 		certChainSubset = append(certChainSubset, certSubset)
 	}
 
-	// Default to using the server FQDN or IP Address used to make the
-	// connection as our hostname value.
-	hostnameValue := inputData.Server.HostValue
-
-	// Allow the user to explicitly specify which hostname should be used
-	// for comparison against the leaf certificate. This works for a
-	// certificate retrieved by a server as well as a certificate
-	// retrieved from a file.
-	if inputData.DNSName != "" {
-		hostnameValue = inputData.DNSName
-	}
+	hostVal := hostnameValue(inputData)
 
 	certChainIssues := CertificateChainIssues{
 		MissingIntermediateCerts: shared.HasMissingIntermediateCerts(certChain),
@@ -112,7 +96,7 @@ func Encode(inputData input.Values) ([]byte, error) {
 		DuplicateCerts:           shared.HasDuplicateCertsInChain(certChain),
 		MisorderedCerts:          shared.HasMisorderedCerts(certChain),
 		ExpiredCerts:             shared.HasExpiredCerts(certChain),
-		HostnameMismatch:         shared.HasHostnameMismatch(hostnameValue, certChain),
+		HostnameMismatch:         shared.HasHostnameMismatch(hostVal, certChain),
 		SelfSignedLeafCert:       shared.HasSelfSignedLeaf(certChain),
 		WeakSignatureAlgorithm:   shared.HasWeakSignatureAlgorithm(certChain),
 	}
@@ -156,4 +140,35 @@ func Encode(inputData input.Values) ([]byte, error) {
 	}
 
 	return payloadJSON, nil
+}
+
+// sansEntries evaluates given input options and either returns all Subject
+// Alternate Names for a given certificate or nil to indicate that a sysadmin
+// opted out of recording SANs entries.
+func sansEntries(cert *x509.Certificate, inputData input.Values) []string {
+	if inputData.OmitSANsEntries {
+		return nil
+	}
+
+	return cert.DNSNames
+}
+
+// hostnameValue is a helper function that evaluates the given hostname values
+// used to perform a certificate service check and returns either the default
+// server value or a custom DNS name value (e.g., virtual host value) if one
+// was specified.
+func hostnameValue(inputData input.Values) string {
+	// Default to using the server FQDN or IP Address used to make the
+	// connection as our hostname value.
+	hostnameValue := inputData.Server.HostValue
+
+	// Allow the user to explicitly specify which hostname should be used
+	// for comparison against the leaf certificate. This works for a
+	// certificate retrieved by a server as well as a certificate
+	// retrieved from a file.
+	if inputData.DNSName != "" {
+		hostnameValue = inputData.DNSName
+	}
+
+	return hostnameValue
 }

--- a/format/v1/errors.go
+++ b/format/v1/errors.go
@@ -5,4 +5,8 @@ import "errors"
 var (
 	// ErrMissingValue indicates that an expected value was missing.
 	ErrMissingValue = errors.New("missing expected value")
+
+	// ErrInvalidPayloadFormat indicates that a given payload is in an
+	// unexpected format.
+	ErrInvalidPayloadFormat = errors.New("given payload format is invalid")
 )

--- a/payload.go
+++ b/payload.go
@@ -48,7 +48,7 @@ var (
 
 	// ErrPayloadFormatVersionTooOld indicates that a specified payload format
 	// version is no longer supported.
-	ErrPayloadFormatVersionTooOld = errors.New("request payload format version is no longer supported")
+	ErrPayloadFormatVersionTooOld = errors.New("requested payload format version is no longer supported")
 
 	// ErrPayloadFormatVersionTooNew indicates that a specified payload format
 	// version is not supported by this package release version.


### PR DESCRIPTION
Various refactor tasks to reduce gocognit and err133 linter warning scores:

- `Encode` and `Decode` functions for both format packages
- multiple functions in `certs` internal package related to identifying certificate chain position and self-signed certs
- misc typos