### PR TITLE
Add `payload.AvailableStableFormatVersions` getter

### DIFF
--- a/payload.go
+++ b/payload.go
@@ -173,6 +173,19 @@ func AvailableFormatVersions() []int {
 	}
 }
 
+// AvailableStableFormatVersions provides a list of all available stable
+// format versions that client applications may choose from when encoding or
+// decoding certificate metadata payloads.
+func AvailableStableFormatVersions() []int {
+	stableFormats := make([]int, 0, len(AvailableFormatVersions()))
+
+	for i := MinStablePayloadVersion; i <= MaxStablePayloadVersion; i++ {
+		stableFormats = append(stableFormats, i)
+	}
+
+	return stableFormats
+}
+
 // latestVersionEncoder is a helper function that provides the latest format
 // version Encode function.
 // func latestVersionEncoder() func(input.Values) ([]byte, error) {


### PR DESCRIPTION
Compliments the existing getter function that provides a list of ALL payload format versions.

refs GH-46